### PR TITLE
release/public-v1: add flags to compile with gfortran-10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_Fortran_FLAGS_DEBUG "-ggdb -Wall")
 endif()
 
+# For gfortran-10+ backward compatibility
+if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER 9.9)
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w -fallow-argument-mismatch")
+endif()
+
 set(fortran_src src/sigio_module.f src/sigio_r_module.f)
 
 set(lib_name ${PROJECT_NAME}_4)


### PR DESCRIPTION
gfortran-10 is much stricter than previous versions of gfortran. This PR adds flags to compile the code with fortran-10 to the release/public-v1 branch. Unfortunately, due to the way the release/public-v1 builds are set up, this needs to be done for each of the NCEPLIBS-* directories that need the additional flags.

Tested to work on macOS with gfortran-10.2.0. Tested to have no impact on machines with Intel compilers or older GNU compilers.