### PR TITLE
Remove -xhost flag from compile options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS
-      "-g -xHOST -traceback -free -convert big_endian -assume byterecl")
+      "-g -traceback -free -convert big_endian -assume byterecl")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_Fortran_FLAGS


### PR DESCRIPTION
Is there any reason sigio needs xhost? Pretty sure this caused a runtime error on Jet because it has multiple CPU types and what it was compiled on doesn't have the same instructions as what it was running on. I don't any other library uses this flag.