### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_Fortran_FLAGS
       "-g -traceback -free -convert big_endian -assume byterecl ${CMAKE_Fortran_FLAGS}")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")


### PR DESCRIPTION
Add the Intel LLVM based compilers as valid targets. Note that the LLVM based compilers are very different than the Classic compilers in their support for compiler options. See https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html for further details.