### PR TITLE
Add IntelLLVM support

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -43,13 +43,13 @@ jobs:
       with:
         repository: Goddard-Fortran-Ecosystem/pFUnit
         path: pfunit
+        submodules: true
 
     - name: build-pfunit
       if: steps.cache-pfunit.outputs.cache-hit != 'true'
       run: |
         cd pfunit
         # Avoid memory sanitizer problem with IntelLLVM for fargparse:
-        find
         sed -i 's:  set(check_all "-check all")::' extern/fArgParse/cmake/IntelLLVM.cmake
         mkdir build
         cd build

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         cd pfunit
         # Avoid memory sanitizer problem with recent IntelLLVM versions:
-        find -name '*.cmake' | xargs sed -i 's:-check all::'
+        for f in $(find -name '*.cmake'); do sed -i 's:-check all::' $f ; done
         mkdir build
         cd build
         ${{ matrix.compilers }} cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         cd pfunit
         # Avoid memory sanitizer problem with recent IntelLLVM versions:
-        sed -i 's:  set(check_all "-check all")::' extern/fArgParse/cmake/IntelLLVM.cmake cmake/IntelLLVM.cmake
+        find -name IntelLLVM.cmake | xargs sed -i 's:  set(check_all "-check all")::'
         mkdir build
         cd build
         ${{ matrix.compilers }} cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -49,11 +49,11 @@ jobs:
       if: steps.cache-pfunit.outputs.cache-hit != 'true'
       run: |
         cd pfunit
-        # Avoid memory sanitizer problem with recent IntelLLVM versions:
-        for f in $(find -name '*.cmake'); do sed -i 's:-check all::' $f ; done
         mkdir build
         cd build
         ${{ matrix.compilers }} cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit
+        # Avoid memory sanitizer problem with recent IntelLLVM versions:
+        for f in $(find -type f); do sed -i 's:-check all::' $f ; done
         make -j2
         make install
 

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         cd pfunit
         # Avoid memory sanitizer problem with recent IntelLLVM versions:
-        find -name IntelLLVM.cmake | xargs sed -i 's:  set(check_all "-check all")::'
+        find -name '*.cmake' | xargs sed -i 's:-check all::'
         mkdir build
         cd build
         ${{ matrix.compilers }} cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -48,6 +48,8 @@ jobs:
       if: steps.cache-pfunit.outputs.cache-hit != 'true'
       run: |
         cd pfunit
+        # Avoid memory sanitizer problem with IntelLLVM for fargparse:
+        sed -i 's:  set(check_all "-check all")::' extern/fArgParse/cmake/IntelLLVM.cmake
         mkdir build
         cd build
         ${{ matrix.compilers }} cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -51,9 +51,7 @@ jobs:
         cd pfunit
         mkdir build
         cd build
-        ${{ matrix.compilers }} cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit
-        # Avoid memory sanitizer problem with recent IntelLLVM versions:
-        for f in $(find -type f); do sed -i 's:-check all::' $f ; done
+        CC=icc FC=ifort cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit
         make -j2
         make install
 

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -1,0 +1,72 @@
+# This is a CI workflow for the NCEPLIBS-sigio project.
+#
+# This workflow builds with the Intel Classic and OneAPI compilers.
+#
+# Alex Richert, Sep 2023
+name: Intel
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+# Use -l to use .bash_profile to load intel setvars.sh
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+jobs:
+  Intel:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compilers: ["CC=icc FC=ifort", "CC=icx FC=ifx"]
+
+    steps:
+
+    # See https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html
+    - name: install-intel
+      run: |
+        cd /tmp
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+        sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
+
+    - name: checkout-pfunit
+      uses: actions/checkout@v2
+      with:
+        repository: Goddard-Fortran-Ecosystem/pFUnit
+        path: pfunit
+
+    - name: build-pfunit
+      if: steps.cache-pfunit.outputs.cache-hit != 'true'
+      run: |
+        cd pfunit
+        mkdir build
+        cd build
+        ${{ matrix.compilers }} cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit
+        make -j2
+        make install
+
+    - name: checkout
+      uses: actions/checkout@v2
+      with: 
+        path: sigio
+
+    - name: build
+      run: |
+        cd sigio
+        mkdir build && cd build
+        ${{ matrix.compilers }} cmake .. -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="~/pfunit"
+        make -j2 VERBOSE=1
+
+    - name: test-sigio
+      run: |
+        cd sigio/build
+        ctest --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -49,6 +49,7 @@ jobs:
       run: |
         cd pfunit
         # Avoid memory sanitizer problem with IntelLLVM for fargparse:
+        find
         sed -i 's:  set(check_all "-check all")::' extern/fArgParse/cmake/IntelLLVM.cmake
         mkdir build
         cd build

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -49,8 +49,8 @@ jobs:
       if: steps.cache-pfunit.outputs.cache-hit != 'true'
       run: |
         cd pfunit
-        # Avoid memory sanitizer problem with IntelLLVM for fargparse:
-        sed -i 's:  set(check_all "-check all")::' extern/fArgParse/cmake/IntelLLVM.cmake
+        # Avoid memory sanitizer problem with recent IntelLLVM versions:
+        sed -i 's:  set(check_all "-check all")::' extern/fArgParse/cmake/IntelLLVM.cmake cmake/IntelLLVM.cmake
         mkdir build
         cd build
         ${{ matrix.compilers }} cmake .. -DSKIP_MPI=YES -DSKIP_ESMF=YES -DSKIP_FHAMCREST=YES -DCMAKE_INSTALL_PREFIX=~/pfunit

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_Fortran_FLAGS
       "-g -traceback -free -convert big_endian -assume byterecl ${CMAKE_Fortran_FLAGS}")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")


### PR DESCRIPTION
This PR adds Intel OneAPI (LLVM) support. Unit test successful with Intel OneAPI 2023.2.0 on personal machine. Had to disable 'check all' for pfunit/fargparse because of a mem sanitizer issue.

Fixes #35 