### PR TITLE
Add CDash workflow

### DIFF
--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -1,0 +1,20 @@
+name: cdash
+on:
+  push:
+    branches:
+    - develop
+    - add_cdash
+
+jobs:
+  cdash:
+    runs-on: ubuntu-latest
+
+    env:
+      FC: gfortran
+      CC: gcc
+      CDASH_TOKEN: ${{ secrets.CDASH_TOKEN }}
+
+    steps:
+
+    - name: CDash
+      uses: NOAA-EMC/ci-cdash@develop

--- a/spack/package.py
+++ b/spack/package.py
@@ -39,5 +39,5 @@ class Sigio(CMakePackage):
         return (None, None, flags)
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")


### PR DESCRIPTION
This PR adds a CI job that creates CDash info and pushes it to https://my.cdash.org/index.php?project=NCEPLIBS-sigio each time a commit is merged into develop.

Successful workflow run: https://github.com/AlexanderRichert-NOAA/NCEPLIBS-sigio/actions/runs/14388869057/job/40350972066